### PR TITLE
feat: race-free multi-arch channel manifest via per-arch fragments

### DIFF
--- a/.woodpecker/canary-linux.yml
+++ b/.woodpecker/canary-linux.yml
@@ -14,9 +14,15 @@
 #   r2_host                — R2 endpoint, e.g. <acct>.r2.cloudflarestorage.com
 #   r2_region              — R2 region (usually "auto")
 #
-# Outputs:
-#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1-linux-canary/tailwindcss-linux-x64
-#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1-linux-canary/manifest.json
+# Outputs (all canary arches share ONE channel so manifests accumulate):
+#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/tailwindcss-linux-x64
+#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/manifest.json
+#
+# Manifest compose (race-free): each arch publishes an immutable per-arch
+# fragment manifest.d/<target>.json (single writer), then composes the channel
+# manifest.json from the fragments named in --compose-targets. Parallel arches
+# never overwrite each other's fragment, so the composed manifest converges to
+# the full target set and any later run deterministically rebuilds it.
 #
 # Limitations:
 #   This pipeline only proves linux-x64 (the agent's native target).
@@ -54,13 +60,14 @@ steps:
       - >-
         mix tailwind.release
         --version 4.2.2
-        --channel v4.2.2-rc1-linux-canary
+        --channel v4.2.2-rc1
         --config-provider testing
         --bucket defdo
         --prefix tailwind_cli_daisyui_ci_canary
         --storage-base-url https://storage.defdo.de
         --plugin daisyui_v5
+        --compose-targets linux-x64,linux-arm64,macos-arm64
         --smoke-test
         --verify-upload
         --verify-smoke-test
-        --overwrite-policy fail
+        --overwrite-policy overwrite

--- a/.woodpecker/release-linux-arm64.yml
+++ b/.woodpecker/release-linux-arm64.yml
@@ -14,9 +14,9 @@
 #   r2_host                — R2 endpoint, e.g. <acct>.r2.cloudflarestorage.com
 #   r2_region              — R2 region (usually "auto")
 #
-# Outputs:
-#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1-linux-arm64-canary/tailwindcss-linux-arm64
-#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1-linux-arm64-canary/manifest.json
+# Outputs (shared canary channel — merges with the other arches):
+#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/tailwindcss-linux-arm64
+#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/manifest.json
 
 labels:
   platform: linux/arm64
@@ -50,13 +50,14 @@ steps:
       - >-
         mix tailwind.release
         --version 4.2.2
-        --channel v4.2.2-rc1-linux-arm64-canary
+        --channel v4.2.2-rc1
         --config-provider testing
         --bucket defdo
         --prefix tailwind_cli_daisyui_ci_canary
         --storage-base-url https://storage.defdo.de
         --plugin daisyui_v5
+        --compose-targets linux-x64,linux-arm64,macos-arm64
         --smoke-test
         --verify-upload
         --verify-smoke-test
-        --overwrite-policy fail
+        --overwrite-policy overwrite

--- a/.woodpecker/release-macos-arm64.yml
+++ b/.woodpecker/release-macos-arm64.yml
@@ -20,9 +20,9 @@
 #   r2_host                — R2 endpoint, e.g. <acct>.r2.cloudflarestorage.com
 #   r2_region              — R2 region (usually "auto")
 #
-# Outputs:
-#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1-macos-canary/tailwindcss-macos-arm64
-#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1-macos-canary/manifest.json
+# Outputs (shared canary channel — merges with the other arches):
+#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/tailwindcss-macos-arm64
+#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/manifest.json
 
 labels:
   platform: darwin/arm64
@@ -54,13 +54,14 @@ steps:
       - >-
         mix tailwind.release
         --version 4.2.2
-        --channel v4.2.2-rc1-macos-canary
+        --channel v4.2.2-rc1
         --config-provider testing
         --bucket defdo
         --prefix tailwind_cli_daisyui_ci_canary
         --storage-base-url https://storage.defdo.de
         --plugin daisyui_v5
+        --compose-targets linux-x64,linux-arm64,macos-arm64
         --smoke-test
         --verify-upload
         --verify-smoke-test
-        --overwrite-policy fail
+        --overwrite-policy overwrite

--- a/lib/defdo/tailwind_builder/deployer.ex
+++ b/lib/defdo/tailwind_builder/deployer.ex
@@ -124,9 +124,20 @@ defmodule Defdo.TailwindBuilder.Deployer do
            {:checksums, maybe_generate_sha256sums(deployed, ctx.generate_checksums)},
          {:manifest, {:ok, manifest}} <-
            {:manifest, maybe_generate_manifest(deployed, version, ctx.generate_manifest, opts)},
+         {:merge_metadata, {:ok, {manifest, sha256sums, extra_metadata}}} <-
+           {:merge_metadata,
+            maybe_merge_remote_metadata(mode, version, manifest, sha256sums, opts)},
          {:metadata_uploads, {:ok, metadata_uploads}} <-
            {:metadata_uploads,
-            maybe_publish_metadata(mode, destination, version, manifest, sha256sums, opts)} do
+            maybe_publish_metadata(
+              mode,
+              destination,
+              version,
+              manifest,
+              sha256sums,
+              extra_metadata,
+              opts
+            )} do
       {:ok,
        %{
          version: version,
@@ -243,12 +254,12 @@ defmodule Defdo.TailwindBuilder.Deployer do
   defp maybe_verify_upload_for(:upload, deployed, opts), do: maybe_verify_upload(deployed, opts)
   defp maybe_verify_upload_for(_mode, _deployed, _opts), do: {:ok, nil}
 
-  defp maybe_publish_metadata(:dry_run, _destination, _version, _manifest, _sums, _opts) do
+  defp maybe_publish_metadata(:dry_run, _destination, _version, _manifest, _sums, _extra, _opts) do
     {:ok, []}
   end
 
-  defp maybe_publish_metadata(_mode, destination, version, manifest, sums, opts) do
-    maybe_upload_release_metadata(destination, version, manifest, sums, opts)
+  defp maybe_publish_metadata(_mode, destination, version, manifest, sums, extra, opts) do
+    maybe_upload_release_metadata(destination, version, manifest, sums, extra, opts)
   end
 
   @doc """
@@ -543,6 +554,280 @@ defmodule Defdo.TailwindBuilder.Deployer do
   end
 
   defp maybe_generate_sha256sums(_deployed_files, false), do: {:ok, nil}
+
+  # Merge this run's single-target manifest + checksums with any manifest already
+  # published to the same channel, so multi-arch builds that publish to one
+  # channel accumulate into a single multi-target manifest instead of
+  # overwriting each other.
+  #
+  # New entries win on filename collision; the latest build's top-level
+  # provenance/built_at is kept. `sha256sums.txt` is regenerated from the merged
+  # file list so the manifest and checksums always agree.
+  #
+  # Skipped for dry-run, when disabled via `merge_manifest: false`, or when there
+  # is no manifest to merge.
+  @file_keys ~w(filename artifact_name target_key build_target remote_key storage_url checksum_sha256 size_bytes size_mb built_at architecture status)a
+  @plugin_keys ~w(name version plugin_key)a
+
+  # Returns `{:ok, {manifest, sha256sums, extra_files}}` where `extra_files` is a
+  # list of `{filename, content}` to publish alongside `manifest.json`/
+  # `sha256sums.txt` (used to publish the per-arch fragment).
+  #
+  # Strategy precedence:
+  #   * `compose_targets` set  → fragment + compose (race-free; preferred for CI).
+  #   * `merge_manifest` (default true) → read-modify-write merge of the channel
+  #     `manifest.json` (best-effort; fine for single-writer / serial runs).
+  #   * neither → publish this run's single-target manifest as-is.
+  defp maybe_merge_remote_metadata(:dry_run, _version, manifest, sums, _opts),
+    do: {:ok, {manifest, sums, []}}
+
+  defp maybe_merge_remote_metadata(_mode, _version, nil, sums, _opts), do: {:ok, {nil, sums, []}}
+
+  defp maybe_merge_remote_metadata(_mode, version, manifest, sums, opts) do
+    cond do
+      is_list(Keyword.get(opts, :compose_targets)) ->
+        compose_channel_metadata(version, manifest, sums, opts)
+
+      Keyword.get(opts, :merge_manifest, true) ->
+        with {:ok, {merged, merged_sums}} <- do_merge_remote_metadata(version, manifest, sums, opts) do
+          {:ok, {merged, merged_sums, []}}
+        end
+
+      true ->
+        {:ok, {manifest, sums, []}}
+    end
+  end
+
+  defp do_merge_remote_metadata(version, manifest, sums, opts) do
+    case fetch_remote_manifest(version, opts) do
+      {:ok, remote} ->
+        {merged, merged_sums} = merge_published_manifest(remote, manifest)
+        {:ok, {merged, merged_sums || sums}}
+
+      :none ->
+        {:ok, {manifest, sums}}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Manifest merge skipped: could not fetch remote manifest (#{inspect(reason)}); " <>
+            "publishing this run's manifest as-is"
+        )
+
+        {:ok, {manifest, sums}}
+    end
+  end
+
+  # Race-free channel manifest: publish this run's single-target manifest as an
+  # immutable per-arch fragment (`manifest.d/<target_key>.json`, written only by
+  # this arch), then compose the channel `manifest.json` by folding this run with
+  # the sibling fragments named in `compose_targets`. Because fragments are
+  # single-writer, concurrent composes converge monotonically to the full set,
+  # and any later run deterministically reconstructs the complete manifest from
+  # fragments. Missing siblings (not built yet) are skipped, not an error.
+  defp compose_channel_metadata(version, manifest, sums, opts) do
+    self_target = manifest_target_key(manifest)
+    fragment = {fragment_filename(self_target), Jason.encode!(manifest, pretty: true)}
+
+    siblings =
+      opts
+      |> Keyword.get(:compose_targets, [])
+      |> List.wrap()
+      |> Enum.map(&to_string/1)
+      |> Enum.reject(&(&1 == self_target))
+      |> Enum.flat_map(fn target ->
+        case fetch_fragment(version, target, opts) do
+          {:ok, sibling} ->
+            [sibling]
+
+          :none ->
+            []
+
+          {:error, reason} ->
+            Logger.warning(
+              "Compose skipped sibling fragment #{target}: #{inspect(reason)}"
+            )
+
+            []
+        end
+      end)
+
+    composed = compose_manifest(manifest, siblings)
+    composed_sums = sha256sums_from_manifest(composed) || sums
+    {:ok, {composed, composed_sums, [fragment]}}
+  end
+
+  @doc """
+  Compose a channel manifest by folding this run's manifest with sibling
+  per-arch manifests. This run wins on `filename` collision (it owns its target);
+  siblings contribute their distinct targets. Order-independent for distinct
+  targets. Pure — no network.
+  """
+  @spec compose_manifest(map(), [map()]) :: map()
+  def compose_manifest(base, siblings) when is_map(base) and is_list(siblings) do
+    Enum.reduce(siblings, base, fn sibling, acc -> merge_manifests(sibling, acc) end)
+  end
+
+  defp fragment_filename(target_key), do: "manifest.d/#{target_key || "unknown"}.json"
+
+  defp manifest_target_key(manifest) do
+    manifest
+    |> manifest_files()
+    |> List.first()
+    |> case do
+      nil -> nil
+      file -> fetch_any(file, :target_key) || fetch_any(file, :filename)
+    end
+  end
+
+  defp fetch_fragment(version, target_key, opts) do
+    url = build_storage_url(fragment_remote_key(target_key, opts, version), opts)
+
+    if is_nil(url) do
+      :none
+    else
+      fetcher = Keyword.get(opts, :manifest_merge_fetcher) || (&default_manifest_merge_fetcher/1)
+
+      case fetcher.(url) do
+        {:ok, body} when is_map(body) -> {:ok, body}
+        {:ok, body} when is_binary(body) -> decode_remote_manifest(body)
+        :not_found -> :none
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp fragment_remote_key(target_key, opts, version) do
+    artifact_remote_key(fragment_filename(target_key), opts, version)
+  end
+
+  defp fetch_remote_manifest(version, opts) do
+    case remote_manifest_url(version, opts) do
+      nil ->
+        :none
+
+      url ->
+        fetcher = Keyword.get(opts, :manifest_merge_fetcher) || (&default_manifest_merge_fetcher/1)
+
+        case fetcher.(url) do
+          {:ok, body} when is_map(body) -> {:ok, body}
+          {:ok, body} when is_binary(body) -> decode_remote_manifest(body)
+          :not_found -> :none
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  defp decode_remote_manifest(body) do
+    case Jason.decode(body) do
+      {:ok, map} when is_map(map) -> {:ok, map}
+      _ -> {:error, :invalid_remote_manifest}
+    end
+  end
+
+  defp remote_manifest_url(version, opts) do
+    build_storage_url(artifact_remote_key("manifest.json", opts, version), opts)
+  end
+
+  defp default_manifest_merge_fetcher(url) do
+    case Req.get(url: url) do
+      {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, %Req.Response{status: 404}} -> :not_found
+      {:ok, %Req.Response{status: status}} -> {:error, {:http_status, status}}
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  @doc """
+  Merge a previously published channel manifest with this run's manifest.
+
+  Returns `{merged_manifest, sha256sums_text}`. Remote file and plugin entries
+  are preserved unless this run publishes the same `filename`/`plugin_key`, in
+  which case the local entry wins. `total_files` is recomputed and
+  `sha256sums_text` is regenerated from the merged file list so the manifest and
+  checksums always agree. Pure — performs no network access. Accepts maps with
+  either atom keys (locally generated) or string keys (decoded remote JSON).
+  """
+  @spec merge_published_manifest(map(), map()) :: {map(), String.t() | nil}
+  def merge_published_manifest(remote, local) when is_map(remote) and is_map(local) do
+    merged = merge_manifests(remote, local)
+    {merged, sha256sums_from_manifest(merged)}
+  end
+
+  defp merge_manifests(remote, local) do
+    remote_files = Enum.map(manifest_files(remote), &normalize_keyed(&1, @file_keys))
+    local_files = Enum.map(manifest_files(local), &normalize_keyed(&1, @file_keys))
+    local_keys = MapSet.new(local_files, &file_key/1)
+
+    merged_files =
+      Enum.reject(remote_files, &MapSet.member?(local_keys, file_key(&1))) ++ local_files
+
+    merged_plugins = merge_plugin_sets(remote, local)
+
+    local
+    |> Map.put(:files, merged_files)
+    |> Map.put(:total_files, length(merged_files))
+    |> Map.put(:plugin_set, merged_plugins)
+    |> put_metadata_plugin_set(merged_plugins)
+  end
+
+  defp merge_plugin_sets(remote, local) do
+    remote_plugins = Enum.map(manifest_plugin_set(remote), &normalize_keyed(&1, @plugin_keys))
+    local_plugins = Enum.map(manifest_plugin_set(local), &normalize_keyed(&1, @plugin_keys))
+    local_keys = MapSet.new(local_plugins, &plugin_key/1)
+
+    Enum.reject(remote_plugins, &MapSet.member?(local_keys, plugin_key(&1))) ++ local_plugins
+  end
+
+  defp put_metadata_plugin_set(%{metadata: %{} = meta} = manifest, plugins),
+    do: Map.put(manifest, :metadata, Map.put(meta, :plugin_set, plugins))
+
+  defp put_metadata_plugin_set(manifest, _plugins), do: manifest
+
+  defp sha256sums_from_manifest(manifest) do
+    lines =
+      manifest
+      |> manifest_files()
+      |> Enum.flat_map(fn file ->
+        name = fetch_any(file, :filename)
+        sum = fetch_any(file, :checksum_sha256)
+        if name && sum, do: ["#{sum}  #{name}"], else: []
+      end)
+      |> Enum.sort()
+
+    case lines do
+      [] -> nil
+      _ -> Enum.join(lines, "\n")
+    end
+  end
+
+  defp manifest_files(manifest), do: fetch_any(manifest, :files) || []
+  defp manifest_plugin_set(manifest), do: fetch_any(manifest, :plugin_set) || []
+
+  defp file_key(file), do: fetch_any(file, :filename) || fetch_any(file, :target_key)
+  defp plugin_key(plugin), do: fetch_any(plugin, :plugin_key) || fetch_any(plugin, :name)
+
+  # JSON fetched from storage has string keys; locally generated maps have atom
+  # keys. Normalize a single entry to atom keys over a fixed, known key set so we
+  # never call String.to_atom on untrusted remote input.
+  defp normalize_keyed(entry, keys) do
+    Enum.reduce(keys, %{}, fn key, acc ->
+      case fetch_any(entry, key) do
+        nil -> acc
+        value -> Map.put(acc, key, value)
+      end
+    end)
+  end
+
+  defp fetch_any(map, atom_key) when is_map(map) do
+    case Map.get(map, atom_key) do
+      nil -> Map.get(map, Atom.to_string(atom_key))
+      value -> value
+    end
+  end
+
+  defp fetch_any(_map, _atom_key), do: nil
 
   defp maybe_verify_upload(deployed, opts) do
     if Keyword.get(opts, :verify_upload, false) do
@@ -875,9 +1160,9 @@ defmodule Defdo.TailwindBuilder.Deployer do
     }
   end
 
-  defp maybe_upload_release_metadata(_destination, _version, nil, nil, _opts), do: {:ok, []}
+  defp maybe_upload_release_metadata(_destination, _version, nil, nil, [], _opts), do: {:ok, []}
 
-  defp maybe_upload_release_metadata(destination, version, manifest, sha256sums, opts)
+  defp maybe_upload_release_metadata(destination, version, manifest, sha256sums, extra, opts)
        when destination in [:r2, :s3] do
     bucket = Keyword.get(opts, :bucket, "defdo")
     prefix = Keyword.get(opts, :prefix, "tailwind_cli_daisyui")
@@ -888,6 +1173,7 @@ defmodule Defdo.TailwindBuilder.Deployer do
         manifest && {"manifest.json", Jason.encode!(manifest, pretty: true)},
         sha256sums && {"sha256sums.txt", ensure_trailing_newline(sha256sums)}
       ]
+      |> Kernel.++(List.wrap(extra))
       |> Enum.reject(&is_nil/1)
       |> Enum.map(fn {filename, content} ->
         upload_content_to_r2(content, filename, bucket, prefix, release_path)
@@ -905,7 +1191,7 @@ defmodule Defdo.TailwindBuilder.Deployer do
     end
   end
 
-  defp maybe_upload_release_metadata(_destination, _version, _manifest, _sha256sums, _opts) do
+  defp maybe_upload_release_metadata(_destination, _version, _manifest, _sha256sums, _extra, _opts) do
     {:ok, []}
   end
 

--- a/lib/defdo/tailwind_builder/release.ex
+++ b/lib/defdo/tailwind_builder/release.ex
@@ -51,7 +51,9 @@ defmodule Defdo.TailwindBuilder.Release do
         :overwrite_policy,
         :tailwind_version,
         :tailwind_cli_version,
-        :source_checksum
+        :source_checksum,
+        :merge_manifest,
+        :compose_targets
       ])
 
     version = Keyword.get(opts, :version, @default_version)
@@ -137,7 +139,9 @@ defmodule Defdo.TailwindBuilder.Release do
               overwrite_policy: overwrite_policy,
               tailwind_version: Keyword.get(opts, :tailwind_version, version),
               tailwind_cli_version: Keyword.get(opts, :tailwind_cli_version, version),
-              source_checksum: Keyword.get(opts, :source_checksum)
+              source_checksum: Keyword.get(opts, :source_checksum),
+              merge_manifest: Keyword.get(opts, :merge_manifest, true),
+              compose_targets: Keyword.get(opts, :compose_targets)
             )} do
       {:ok,
        %{

--- a/lib/mix/tasks/tailwind/release.ex
+++ b/lib/mix/tasks/tailwind/release.ex
@@ -58,7 +58,9 @@ defmodule Mix.Tasks.Tailwind.Release do
           verify_upload: :boolean,
           verify_smoke_test: :boolean,
           dry_run: :boolean,
-          overwrite_policy: :string
+          overwrite_policy: :string,
+          compose_targets: :string,
+          merge_manifest: :boolean
         ],
         aliases: [
           v: :version,
@@ -115,7 +117,9 @@ defmodule Mix.Tasks.Tailwind.Release do
         verify_upload: Keyword.get(opts, :verify_upload, false),
         verify_smoke_test: Keyword.get(opts, :verify_smoke_test, false),
         dry_run: dry_run,
-        overwrite_policy: parse_overwrite_policy(Keyword.get(opts, :overwrite_policy))
+        overwrite_policy: parse_overwrite_policy(Keyword.get(opts, :overwrite_policy)),
+        merge_manifest: Keyword.get(opts, :merge_manifest, true),
+        compose_targets: parse_compose_targets(Keyword.get(opts, :compose_targets))
       ]
       |> Enum.reject(fn {_key, value} -> is_nil(value) end)
 
@@ -158,6 +162,22 @@ defmodule Mix.Tasks.Tailwind.Release do
     Mix.raise(
       "Unsupported overwrite policy: #{other}. Expected one of: fail, overwrite, promote_only"
     )
+  end
+
+  # Comma-separated target keys, e.g. "linux-x64,linux-arm64,macos-arm64". When
+  # set, the release publishes a per-arch manifest fragment and composes the
+  # channel manifest from these targets' fragments (race-free across arches).
+  defp parse_compose_targets(nil), do: nil
+
+  defp parse_compose_targets(value) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> case do
+      [] -> nil
+      targets -> targets
+    end
   end
 
   defp parse_config_provider(nil), do: ProductionConfigProvider

--- a/test/defdo/tailwind_builder/deployer_test.exs
+++ b/test/defdo/tailwind_builder/deployer_test.exs
@@ -604,4 +604,144 @@ defmodule Defdo.TailwindBuilder.DeployerTest do
       assert res.smoke_test == :failed
     end
   end
+
+  describe "merge_published_manifest/2" do
+    # Remote (already published) manifest: only the macOS target, string keys as
+    # decoded from storage JSON.
+    defp remote_macos_manifest do
+      %{
+        "manifest_schema_version" => 1,
+        "release_channel" => "v4.2.2-rc1",
+        "tailwind_cli_version" => "4.2.2",
+        "total_files" => 1,
+        "plugin_set" => [%{"name" => "daisyui", "version" => "5.5.19", "plugin_key" => "daisyui_v5"}],
+        "files" => [
+          %{
+            "filename" => "tailwindcss-macos-arm64",
+            "target_key" => "macos-arm64",
+            "build_target" => "aarch64-apple-darwin",
+            "artifact_name" => "tailwindcss-macos-arm64",
+            "storage_url" => "https://storage.defdo.de/p/v4.2.2-rc1/tailwindcss-macos-arm64",
+            "checksum_sha256" => "macsum",
+            "size_bytes" => 77_827_552,
+            "built_at" => "2026-06-28T00:19:04Z"
+          }
+        ]
+      }
+    end
+
+    # Local (this run) manifest: only the linux-x64 target, atom keys as produced
+    # by generate_deployment_manifest/3.
+    defp local_linux_manifest do
+      %{
+        manifest_schema_version: 1,
+        release_channel: "v4.2.2-rc1",
+        tailwind_cli_version: "4.2.2",
+        total_files: 1,
+        metadata: %{plugin_set: [%{name: "daisyui", version: "5.5.19", plugin_key: "daisyui_v5"}]},
+        plugin_set: [%{name: "daisyui", version: "5.5.19", plugin_key: "daisyui_v5"}],
+        files: [
+          %{
+            filename: "tailwindcss-linux-x64",
+            target_key: "linux-x64",
+            build_target: "x86_64-unknown-linux-gnu",
+            artifact_name: "tailwindcss-linux-x64",
+            storage_url: "https://storage.defdo.de/p/v4.2.2-rc1/tailwindcss-linux-x64",
+            checksum_sha256: "linsum",
+            size_bytes: 1234,
+            built_at: "2026-06-30T00:00:00Z"
+          }
+        ]
+      }
+    end
+
+    test "accumulates a new target into a previously published manifest" do
+      {merged, sums} = Deployer.merge_published_manifest(remote_macos_manifest(), local_linux_manifest())
+
+      target_keys = merged.files |> Enum.map(&(&1[:target_key])) |> Enum.sort()
+      assert target_keys == ["linux-x64", "macos-arm64"]
+      assert merged.total_files == 2
+      # Plugin set de-duplicated by plugin_key, not doubled.
+      assert length(merged.plugin_set) == 1
+
+      # sha256sums regenerated from the merged file list, sorted, both targets.
+      assert sums == "linsum  tailwindcss-linux-x64\nmacsum  tailwindcss-macos-arm64"
+    end
+
+    test "local entry wins on filename collision (re-publishing same target)" do
+      remote = remote_macos_manifest()
+
+      local =
+        local_linux_manifest()
+        |> Map.put(:files, [
+          %{
+            filename: "tailwindcss-macos-arm64",
+            target_key: "macos-arm64",
+            artifact_name: "tailwindcss-macos-arm64",
+            storage_url: "https://storage.defdo.de/p/v4.2.2-rc1/tailwindcss-macos-arm64",
+            checksum_sha256: "newmacsum",
+            size_bytes: 999,
+            built_at: "2026-06-30T00:00:00Z"
+          }
+        ])
+
+      {merged, sums} = Deployer.merge_published_manifest(remote, local)
+
+      assert merged.total_files == 1
+      [file] = merged.files
+      assert file[:checksum_sha256] == "newmacsum"
+      assert sums == "newmacsum  tailwindcss-macos-arm64"
+    end
+  end
+
+  describe "compose_manifest/2" do
+    defp sibling_manifest(filename, target_key, checksum) do
+      %{
+        "manifest_schema_version" => 1,
+        "files" => [
+          %{
+            "filename" => filename,
+            "target_key" => target_key,
+            "artifact_name" => filename,
+            "storage_url" => "https://storage.defdo.de/p/v4.2.2-rc1/#{filename}",
+            "checksum_sha256" => checksum,
+            "size_bytes" => 100,
+            "built_at" => "2026-06-30T00:00:00Z"
+          }
+        ]
+      }
+    end
+
+    test "folds this run with sibling fragments into one multi-target manifest" do
+      base = local_linux_manifest()
+
+      siblings = [
+        sibling_manifest("tailwindcss-macos-arm64", "macos-arm64", "macsum"),
+        sibling_manifest("tailwindcss-linux-arm64", "linux-arm64", "armsum")
+      ]
+
+      composed = Deployer.compose_manifest(base, siblings)
+
+      target_keys = composed.files |> Enum.map(&(&1[:target_key])) |> Enum.sort()
+      assert target_keys == ["linux-arm64", "linux-x64", "macos-arm64"]
+      assert composed.total_files == 3
+    end
+
+    test "fold is order-independent for distinct targets" do
+      base = local_linux_manifest()
+      mac = sibling_manifest("tailwindcss-macos-arm64", "macos-arm64", "macsum")
+      arm = sibling_manifest("tailwindcss-linux-arm64", "linux-arm64", "armsum")
+
+      keys = fn m -> m.files |> Enum.map(&(&1[:target_key])) |> Enum.sort() end
+
+      assert keys.(Deployer.compose_manifest(base, [mac, arm])) ==
+               keys.(Deployer.compose_manifest(base, [arm, mac]))
+    end
+
+    test "no siblings (others not built yet) yields just this run's target" do
+      composed = Deployer.compose_manifest(local_linux_manifest(), [])
+      assert composed.total_files == 1
+      assert [%{target_key: "linux-x64"}] = composed.files
+    end
+  end
 end


### PR DESCRIPTION
## What
Closes the parallel-canary manifest race. Each per-arch release publishes an immutable fragment `manifest.d/<target_key>.json` (single writer) and composes the channel `manifest.json` from the fragments named in `--compose-targets`. Parallel arch pipelines never overwrite each other; the composed manifest converges to the full target set and any later run rebuilds it deterministically.

## Changes
- `deployer.ex`: per-arch fragment publish, `compose_manifest/2`, compose branch; legacy `merge_manifest` read-modify-write kept for serial runs. Pure entry points `merge_published_manifest/2` + `compose_manifest/2`.
- `release.ex` + `mix tailwind.release`: `--compose-targets` and `--merge-manifest` plumbed.
- `.woodpecker/*`: 3 canary pipelines unified to one channel (`v4.2.2-rc1` under `tailwind_cli_daisyui_ci_canary`), `overwrite` policy, `--compose-targets linux-x64,linux-arm64,macos-arm64`.

## Tests
273 tests, 0 failures. 5 new cases: merge union, collision precedence, compose fold, order-independence, no-siblings.

## Notes
Production channel still fills only after CI runs (tag `0.1.0`, R2 secrets, mac agent, `canary/v4.2.2` push) — operational, out of scope here.