### PR TITLE
fix: whitelist merge_manifest/compose_targets in Deployer.deploy

### DIFF
--- a/lib/defdo/tailwind_builder/deployer.ex
+++ b/lib/defdo/tailwind_builder/deployer.ex
@@ -64,7 +64,10 @@ defmodule Defdo.TailwindBuilder.Deployer do
         :existence_checker,
         :tailwind_version,
         :tailwind_cli_version,
-        :source_checksum
+        :source_checksum,
+        :merge_manifest,
+        :compose_targets,
+        :manifest_merge_fetcher
       ])
 
     version = opts[:version] || raise ArgumentError, "version is required"

--- a/test/defdo/tailwind_builder/deployer_test.exs
+++ b/test/defdo/tailwind_builder/deployer_test.exs
@@ -534,6 +534,29 @@ defmodule Defdo.TailwindBuilder.DeployerTest do
                "https://storage.defdo.de/tailwind_cli_daisyui/v4.2.2-rc1/#{artifact}"
     end
 
+    test "accepts merge_manifest and compose_targets opts (regression)", %{dir: dir} do
+      # These opts are threaded from the release task; deploy/1 must whitelist
+      # them. Dry-run skips the compose/merge network step, so this only proves
+      # the option validation does not raise.
+      assert {:ok, result} =
+               Deployer.deploy(
+                 version: "4.2.2",
+                 source_path: dir,
+                 destination: :r2,
+                 dry_run: true,
+                 validate_binaries: false,
+                 smoke_test_binaries: false,
+                 bucket: "defdo",
+                 prefix: "tailwind_cli_daisyui_ci_canary",
+                 release_channel: "v4.2.2-rc1",
+                 storage_base_url: "https://storage.defdo.de",
+                 merge_manifest: true,
+                 compose_targets: ["linux-x64", "linux-arm64", "macos-arm64"]
+               )
+
+      assert result.dry_run == true
+    end
+
     test "is deterministic across reruns", %{dir: dir} do
       assert {:ok, run1} = dry_run_deploy(dir)
       assert {:ok, run2} = dry_run_deploy(dir)


### PR DESCRIPTION
## Bug
A real `mix tailwind.release` with the compose flags the canary pipelines now pass (`--compose-targets`, `--merge-manifest`) **raises `ArgumentError` after a successful build**, right before deploy:

> unknown keys [:compose_targets, :merge_manifest] ... Keyword.validate!/2 at deployer.ex:43

#6 threaded these opts from the release task into `Deployer.deploy/1`, but `do_deploy/1`'s `Keyword.validate!` allowlist was never extended. Unit tests exercised the pure `merge_published_manifest`/`compose_manifest` functions directly and missed it; a full **dry-run release surfaced it**.

## Fix
- Add `:merge_manifest`, `:compose_targets`, `:manifest_merge_fetcher` to the `do_deploy/1` allowlist.
- Regression test through `deploy/1`'s validate path with the new opts.

## Verified
End-to-end on a real darwin/arm64 build: `mix tailwind.release --dry-run` now builds natively (pnpm/oxide/bun, 4 steps) and generates manifest + checksums without raising. 274 tests, 0 failures.

## Impact
Without this, **every canary pipeline would fail at deploy** — i.e. Phase 0 would have produced zero artifacts despite green builds. Blocks the canary push until merged.