### PR TITLE
fix: load R2/S3 storage config from env in Release.run

### DIFF
--- a/lib/defdo/tailwind_builder/release.ex
+++ b/lib/defdo/tailwind_builder/release.ex
@@ -103,6 +103,7 @@ defmodule Defdo.TailwindBuilder.Release do
            ),
          {:plugins, {:ok, resolved_plugins, plugin_set}} <-
            {:plugins, resolve_plugins(plugins, config_provider)},
+         :ok <- ensure_storage_config(destination, dry_run),
          {:download, {:ok, download_result}} <-
            {:download, download_source(version, source_path, config_provider)},
          {:apply_plugins, {:ok, plugin_results}} <-
@@ -289,6 +290,40 @@ defmodule Defdo.TailwindBuilder.Release do
 
       _ ->
         %{name: plugin_name, version: version_spec, plugin_key: plugin_name}
+    end
+  end
+
+  # Ensure R2/S3 credentials are loaded into application config before any
+  # upload. The Mix task sets this from env, but library callers (the worker
+  # Executor calling run/1 directly) do not — without this, storage_req builds a
+  # SigV4 signer with a nil access key and uploads fail with a cryptic
+  # ArgumentError. Loads from env as a fallback when not already configured.
+  defp ensure_storage_config(destination, dry_run)
+       when destination in [:r2, :s3] and dry_run == false do
+    case Application.get_env(:tailwind_builder, :storage) do
+      storage when is_list(storage) and storage != [] -> :ok
+      _ -> load_storage_config_from_env()
+    end
+  end
+
+  defp ensure_storage_config(_destination, _dry_run), do: :ok
+
+  defp load_storage_config_from_env do
+    config = %{
+      access_key_id: System.get_env("R2_ACCESS_KEY_ID") || System.get_env("AWS_ACCESS_KEY_ID"),
+      secret_access_key:
+        System.get_env("R2_SECRET_ACCESS_KEY") || System.get_env("AWS_SECRET_ACCESS_KEY"),
+      host: Deployer.normalize_storage_host(System.get_env("R2_HOST")),
+      region: System.get_env("R2_REGION") || System.get_env("AWS_REGION") || "auto"
+    }
+
+    case for({key, value} <- config, is_nil(value), do: key) do
+      [] ->
+        Application.put_env(:tailwind_builder, :storage, Map.to_list(config))
+        :ok
+
+      missing ->
+        {:error, {:missing_storage_config, missing}}
     end
   end
 

--- a/test/defdo/tailwind_builder/release_test.exs
+++ b/test/defdo/tailwind_builder/release_test.exs
@@ -16,6 +16,16 @@ defmodule Defdo.TailwindBuilder.ReleaseTest do
     original_storage_base_url = Application.get_env(:tailwind_builder, :storage_base_url)
     original_storage = Application.get_env(:tailwind_builder, :storage)
 
+    # Fake storage config so run/1's pre-deploy credential check passes for the
+    # r2 happy-path tests (deploy itself is mocked). Error-path tests fail at
+    # plugin/policy validation before this is consulted.
+    Application.put_env(:tailwind_builder, :storage,
+      access_key_id: "test-key",
+      secret_access_key: "test-secret",
+      host: "test.r2.cloudflarestorage.com",
+      region: "auto"
+    )
+
     on_exit(fn ->
       restore_env(:storage_base_url, original_storage_base_url)
       restore_env(:storage, original_storage)


### PR DESCRIPTION
## Bug (found by the worker→hub loop)
`Release.run/1` is the library entry point the worker Executor calls. Unlike the Mix task, it never loaded R2 credentials from env into app config, so `storage_req` built a SigV4 signer with a `nil` access key → uploads failed with `missing :access_key_id in :aws_sigv4 option`.

## Fix
`ensure_storage_config/2`: for r2/s3 non-dry-run, load `R2_*`/`AWS_*` env into `:tailwind_builder, :storage` when not already set; return `{:error, {:missing_storage_config, keys}}` if incomplete. Runs **after** plugin/policy validation (those errors still surface first) but **before** download/build (fail fast — no 30s build before an auth failure).

## Evidence
Ran the full local loop: hub + worker daemon, `POST /api/v1/jobs` → worker claims → real macOS build → **upload now succeeds** → manifest/fragment/sha in R2 → worker reports → hub records `succeeded`. 274 tests, 0 failures.