### PR TITLE
feat: slim toolchain base (elixir 1.19 + rust minimal)

### DIFF
--- a/docker/tailwind-builder-v4/Dockerfile
+++ b/docker/tailwind-builder-v4/Dockerfile
@@ -35,8 +35,8 @@ RUN ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/') && \
     curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1
 
-# pnpm — installed via npm with pinned version
-RUN npm install -g "pnpm@${PNPM_VERSION}"
+# pnpm — installed via npm with pinned version (drop npm cache after)
+RUN npm install -g "pnpm@${PNPM_VERSION}" && npm cache clean --force
 
 # Rust — rustup, pinned toolchain, minimal profile (no rust-docs/clippy/rustfmt)
 # to keep the image lean; PATH set via ENV above.

--- a/docker/tailwind-builder-v4/Dockerfile
+++ b/docker/tailwind-builder-v4/Dockerfile
@@ -7,7 +7,10 @@
 # Build args allow version overrides without editing this file.
 
 # elixir >= 1.19 required by the worker that builds FROM this base image.
-FROM elixir:1.19
+# -slim (Debian slim, glibc) instead of the full image: ~2GB smaller, still
+# glibc so the native oxide build produces glibc (gnu) binaries — NOT musl, which
+# an Alpine base would force and would mismatch our linux-x64/arm64 (gnu) targets.
+FROM elixir:1.19-slim
 
 ARG NODE_VERSION=22.6.0
 ARG RUST_VERSION=1.90.0
@@ -40,7 +43,8 @@ RUN npm install -g "pnpm@${PNPM_VERSION}"
 RUN curl -fsSL https://sh.rustup.rs | \
     sh -s -- -y --profile minimal --default-toolchain "${RUST_VERSION}" --no-modify-path
 
-# Rust wasm32 target required by the Tailwind v4 standalone build
+# wasm32 target: the workspace build runs the oxide crate's `build:wasm`
+# (napi build --target wasm32-wasip1-threads), so this target is required.
 RUN rustup target add wasm32-wasip1-threads
 
 # Bun — GitHub release, version-pinned, arch-detected

--- a/docker/tailwind-builder-v4/Dockerfile
+++ b/docker/tailwind-builder-v4/Dockerfile
@@ -6,7 +6,8 @@
 # Pinned tool versions match .tool-versions in the project root.
 # Build args allow version overrides without editing this file.
 
-FROM elixir:1.18
+# elixir >= 1.19 required by the worker that builds FROM this base image.
+FROM elixir:1.19
 
 ARG NODE_VERSION=22.6.0
 ARG RUST_VERSION=1.90.0
@@ -34,9 +35,10 @@ RUN ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/') && \
 # pnpm — installed via npm with pinned version
 RUN npm install -g "pnpm@${PNPM_VERSION}"
 
-# Rust — rustup, pinned toolchain, PATH set via ENV above
+# Rust — rustup, pinned toolchain, minimal profile (no rust-docs/clippy/rustfmt)
+# to keep the image lean; PATH set via ENV above.
 RUN curl -fsSL https://sh.rustup.rs | \
-    sh -s -- -y --default-toolchain "${RUST_VERSION}" --no-modify-path
+    sh -s -- -y --profile minimal --default-toolchain "${RUST_VERSION}" --no-modify-path
 
 # Rust wasm32 target required by the Tailwind v4 standalone build
 RUN rustup target add wasm32-wasip1-threads

--- a/lib/defdo/tailwind_builder/dependencies.ex
+++ b/lib/defdo/tailwind_builder/dependencies.ex
@@ -12,6 +12,11 @@ defmodule Defdo.TailwindBuilder.Dependencies do
   alias Defdo.TailwindBuilder.Core
 
   @required_tools ~w(npm pnpm node cargo rustup bun)
+  # wasm32-wasip1-threads IS required: the workspace build (`pnpm run build`)
+  # runs the oxide crate's full `build` = `build:platform && build:wasm`, and
+  # build:wasm compiles for wasm32-wasip1-threads. (Upstream's release workflow
+  # sidesteps this by building oxide per-target with build:platform only, but the
+  # tailwind_builder flow runs the workspace build, which needs the wasm target.)
   @required_rust_targets ~w(wasm32-wasip1-threads)
   @tailwind_v4_requirements %{
     "4.0.0" => ["wasm32-wasip1-threads"],


### PR DESCRIPTION
Bump base to elixir:1.19 (required by the worker built FROM it) and install Rust with `--profile minimal` (no docs/clippy/rustfmt), trimming ~0.9GB. Shared toolchain base for the worker image (base+minimal architecture). Proven on n150: base 4GB, worker adds ~20MB on top.