### PR TITLE
feat: bump canary to Tailwind 4.3.2 + DaisyUI 5.6.7

### DIFF
--- a/.woodpecker/canary-linux.yml
+++ b/.woodpecker/canary-linux.yml
@@ -1,7 +1,7 @@
 ---
 # Canary Linux release pipeline.
 #
-# Runs the v4.2.2-rc1 Tailwind + DaisyUI release flow inside the toolchain
+# Runs the v4.3.2-rc1 Tailwind + DaisyUI release flow inside the toolchain
 # container image, targeting the linux-x64 canary prefix on R2.
 #
 # Trigger:
@@ -15,8 +15,8 @@
 #   r2_region              — R2 region (usually "auto")
 #
 # Outputs (all canary arches share ONE channel so manifests accumulate):
-#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/tailwindcss-linux-x64
-#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/manifest.json
+#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.3.2-rc1/tailwindcss-linux-x64
+#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.3.2-rc1/manifest.json
 #
 # Manifest compose (race-free): each arch publishes an immutable per-arch
 # fragment manifest.d/<target>.json (single writer), then composes the channel
@@ -59,8 +59,8 @@ steps:
       - mix deps.get
       - >-
         mix tailwind.release
-        --version 4.2.2
-        --channel v4.2.2-rc1
+        --version 4.3.2
+        --channel v4.3.2-rc1
         --config-provider testing
         --bucket defdo
         --prefix tailwind_cli_daisyui_ci_canary

--- a/.woodpecker/release-linux-arm64.yml
+++ b/.woodpecker/release-linux-arm64.yml
@@ -15,8 +15,8 @@
 #   r2_region              — R2 region (usually "auto")
 #
 # Outputs (shared canary channel — merges with the other arches):
-#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/tailwindcss-linux-arm64
-#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/manifest.json
+#   Published artifact: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.3.2-rc1/tailwindcss-linux-arm64
+#   Published manifest: https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.3.2-rc1/manifest.json
 
 labels:
   platform: linux/arm64
@@ -49,8 +49,8 @@ steps:
       - mix deps.get
       - >-
         mix tailwind.release
-        --version 4.2.2
-        --channel v4.2.2-rc1
+        --version 4.3.2
+        --channel v4.3.2-rc1
         --config-provider testing
         --bucket defdo
         --prefix tailwind_cli_daisyui_ci_canary

--- a/.woodpecker/release-macos-arm64.yml
+++ b/.woodpecker/release-macos-arm64.yml
@@ -17,7 +17,7 @@
 #   r2_secret_access_key, r2_host, r2_region.
 #
 # Output (shared canary channel, merges with the linux arches):
-#   https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.2.2-rc1/tailwindcss-macos-arm64
+#   https://storage.defdo.de/tailwind_cli_daisyui_ci_canary/v4.3.2-rc1/tailwindcss-macos-arm64
 
 labels:
   platform: darwin/arm64
@@ -50,8 +50,8 @@ steps:
       - mix deps.get
       - >-
         mix tailwind.release
-        --version 4.2.2
-        --channel v4.2.2-rc1
+        --version 4.3.2
+        --channel v4.3.2-rc1
         --config-provider testing
         --bucket defdo
         --prefix tailwind_cli_daisyui_ci_canary

--- a/lib/defdo/tailwind_builder.ex
+++ b/lib/defdo/tailwind_builder.ex
@@ -37,7 +37,7 @@ defmodule Defdo.TailwindBuilder do
       "statement" => ~s['daisyui': require('daisyui')]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.5.19"]
+      "version" => ~s["daisyui": "5.6.7"]
       # No "statement" for v4.x - uses index.ts patching with ES modules instead
     }
   }

--- a/lib/mix/tasks/tailwind/release.ex
+++ b/lib/mix/tasks/tailwind/release.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Tailwind.Release do
   @moduledoc """
   Build and publish a Tailwind standalone release candidate.
 
-  Defaults to Tailwind 4.2.2 with DaisyUI 5.5.19 and release channel v4.2.2-rc1.
+  Defaults to Tailwind 4.3.2 with DaisyUI 5.6.7 and release channel v4.3.2-rc1.
 
   ## Options
 
@@ -102,8 +102,8 @@ defmodule Mix.Tasks.Tailwind.Release do
 
     release_opts =
       [
-        version: Keyword.get(opts, :version, "4.2.2"),
-        release_channel: Keyword.get(opts, :channel, "v4.2.2-rc1"),
+        version: Keyword.get(opts, :version, "4.3.2"),
+        release_channel: Keyword.get(opts, :channel, "v4.3.2-rc1"),
         source_path: Keyword.get(opts, :source_path),
         bucket: Keyword.get(opts, :bucket, System.get_env("TAILWIND_R2_BUCKET", "defdo")),
         prefix:


### PR DESCRIPTION
Targets the versions actually in use. Bumps daisyui_v5 plugin pin (5.5.19→5.6.7) + --version/--channel in all 3 canary pipelines (→4.3.2/v4.3.2-rc1) + mix task defaults. New R2 channel v4.3.2-rc1.