### PR TITLE
test: fix flaky ConfigProvider behavior check

### DIFF
--- a/test/defdo/tailwind_builder/config_providers_test.exs
+++ b/test/defdo/tailwind_builder/config_providers_test.exs
@@ -308,6 +308,10 @@ defmodule Defdo.TailwindBuilder.ConfigProvidersTest do
 
     test "all providers implement required behavior functions" do
       for provider <- @providers do
+        # Ensure the module is loaded first: function_exported?/3 returns false
+        # for a module whose code hasn't been loaded yet, which made this test
+        # flaky across runs/arches depending on load order.
+        assert Code.ensure_loaded?(provider)
         # Required functions from ConfigProvider behavior
         assert function_exported?(provider, :get_supported_plugins, 0)
         assert function_exported?(provider, :get_known_checksums, 0)


### PR DESCRIPTION
function_exported?/3 returns false for a not-yet-loaded module → the provider-behavior test failed non-deterministically across arches. Ensure the module is loaded first.