### PR TITLE
fix(base): bump toolchain for Tailwind 4.3.x (corepack pnpm, node/rust/bun)

### DIFF
--- a/docker/tailwind-builder-v4/Dockerfile
+++ b/docker/tailwind-builder-v4/Dockerfile
@@ -12,10 +12,16 @@
 # an Alpine base would force and would mismatch our linux-x64/arm64 (gnu) targets.
 FROM elixir:1.19-slim
 
-ARG NODE_VERSION=22.6.0
-ARG RUST_VERSION=1.90.0
-ARG BUN_VERSION=1.2.23
-ARG PNPM_VERSION=9.15.9
+# Versions track what recent Tailwind releases require. Tailwind 4.3.x bumped
+# its whole toolchain vs 4.2.x: node >=22.13 (pnpm 11 needs it), pnpm 11.9.0
+# (packageManager field; applies the lightningcss pnpm-patch that lets the bun
+# standalone embed lightningcss's native .node), rust 1.95.0 (rust-toolchain.toml),
+# bun 1.3.14. pnpm is provided via corepack so each Tailwind version's pinned
+# packageManager is used automatically (9.6.0 for 4.2.2, 11.9.0 for 4.3.2).
+ARG NODE_VERSION=22.20.0
+ARG RUST_VERSION=1.95.0
+ARG BUN_VERSION=1.3.14
+ARG PNPM_VERSION=11.9.0
 
 ENV LANG=C.UTF-8
 ENV PATH="/root/.cargo/bin:/root/.bun/bin:${PATH}"
@@ -41,8 +47,11 @@ RUN ARCH=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/') && \
     curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.xz" \
     | tar -xJ -C /usr/local --strip-components=1
 
-# pnpm — installed via npm with pinned version (drop npm cache after)
-RUN npm install -g "pnpm@${PNPM_VERSION}" && npm cache clean --force
+# pnpm — via corepack so the version follows each source's `packageManager`
+# field (Tailwind 4.2.2 -> pnpm 9.6.0, 4.3.2 -> pnpm 11.9.0). corepack ships with
+# Node. Activate a sane default; the source's packageManager overrides it, and
+# the lightningcss pnpm-patch only applies with the version the source pins.
+RUN corepack enable && corepack prepare "pnpm@${PNPM_VERSION}" --activate && npm cache clean --force
 
 # Rust — rustup, pinned toolchain, minimal profile (no rust-docs/clippy/rustfmt)
 # to keep the image lean; PATH set via ENV above.

--- a/docs/CI_BASE_IMAGE_RUNBOOK.md
+++ b/docs/CI_BASE_IMAGE_RUNBOOK.md
@@ -135,6 +135,30 @@ kubectl -n defdo-ci exec deploy/buildkit-arm64 -- buildctl debug workers   # lin
 kubectl -n defdo-ci exec deploy/buildkit-arm64 -- getent hosts hub.defdo.ninja  # 10.43.231.228
 ```
 
+## Tailwind version bumps require toolchain bumps
+
+A new Tailwind release can move its whole build toolchain, and the base must
+match or the standalone build silently produces a binary that **builds but won't
+run** (the smoke test catches it). Concrete example — 4.2.2 → 4.3.2:
+
+| Tool | 4.2.2 | 4.3.2 | Where pinned |
+| --- | --- | --- | --- |
+| node | 22.6.0 | **>= 22.13** | implied by pnpm 11 |
+| pnpm | 9.6.0 | **11.9.0** | root `package.json` `packageManager` |
+| rust | (base default) | **1.95.0** | `rust-toolchain.toml` |
+| bun | ^1.3.9 | ^1.3.14 | `@tailwindcss-standalone` dep |
+
+The subtle one: Tailwind **patches `lightningcss` via a pnpm patch**. In 4.2.2 the
+patch lives in `package.json` `patchedDependencies` (pnpm 9 applies it); in 4.3.2
+it moved to `pnpm-workspace.yaml` (pnpm 10+ format). With the wrong pnpm the patch
+is **not applied**, lightningcss's native loader stays unpatched, and `bun build
+--compile` fails to embed `lightningcss.<target>.node` → the binary dies at
+runtime with `Cannot find module '../lightningcss.<target>.node'`. That's why the
+base uses **corepack** for pnpm (each source's `packageManager` wins) instead of a
+single global pnpm. rust is pinned per-source via `rust-toolchain.toml`, so the
+base ships `RUST_VERSION` with `wasm32-wasip1-threads` added for it; if a future
+release pins a different rust channel, add the wasm32 target for that channel too.
+
 ## Rebuild the base (after an Elixir/Rust/Node/Bun bump)
 
 Sources of truth for versions:


### PR DESCRIPTION
4.3.2 standalone builds but won't run (`Cannot find lightningcss.<target>.node`). Root cause: 4.3.x moved its lightningcss pnpm-patch to `pnpm-workspace.yaml` (pnpm 10+); base pnpm 9.15.9 doesn't apply it -> bun --compile can't embed the native .node. **Confirmed** by building+running the 4.3.2 standalone with node 22.20.0 + pnpm 11.9.0 (via corepack) + rust 1.95.0 + bun 1.3.14. pnpm now via corepack so each source's packageManager wins (keeps 4.2.2 working). Requires a base image rebuild to take effect.