### PR TITLE
fix: DaisyUI 5.6.7 in config providers (effective plugin version)

### DIFF
--- a/lib/defdo/tailwind_builder/build_quick_test.ex
+++ b/lib/defdo/tailwind_builder/build_quick_test.ex
@@ -31,14 +31,14 @@ defmodule Defdo.TailwindBuilder.BuildQuickTest do
   @test_scenarios %{
     v4_basic: %{
       version: "4.2.2",
-      plugin: %{"version" => ~s["daisyui": "5.5.19"]},
+      plugin: %{"version" => ~s["daisyui": "5.6.7"]},
       description: "Basic Tailwind v4 with DaisyUI v5",
       expected_duration_ms: 90_000,
       test_css: "@import \"tailwindcss\"; @plugin \"daisyui\";"
     },
     v4_with_theme: %{
       version: "4.2.2",
-      plugin: %{"version" => ~s["daisyui": "5.5.19"]},
+      plugin: %{"version" => ~s["daisyui": "5.6.7"]},
       theme: %{
         "mytheme" => %{
           "primary" => "#570df8",
@@ -65,7 +65,7 @@ defmodule Defdo.TailwindBuilder.BuildQuickTest do
     },
     cross_platform: %{
       version: "4.2.2",
-      plugin: %{"version" => ~s["daisyui": "5.5.19"]},
+      plugin: %{"version" => ~s["daisyui": "5.6.7"]},
       target_arch: "linux-x64",
       description: "Cross-platform build test (macOS → Linux)",
       expected_duration_ms: 100_000,

--- a/lib/defdo/tailwind_builder/config_providers/development_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/development_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.DevelopmentConfigProvider do
       "compatible_versions" => ["3.x", "4.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.5.19"],
+      "version" => ~s["daisyui": "5.6.7"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/config_providers/production_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/production_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.ProductionConfigProvider do
       "compatible_versions" => ["3.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.5.19"],
+      "version" => ~s["daisyui": "5.6.7"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/config_providers/staging_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/staging_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.StagingConfigProvider do
       "compatible_versions" => ["3.x", "4.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.5.19"],
+      "version" => ~s["daisyui": "5.6.7"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/config_providers/testing_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/testing_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.TestingConfigProvider do
       "compatible_versions" => ["3.x", "4.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.5.19"],
+      "version" => ~s["daisyui": "5.6.7"],
       "description" => "Test plugin for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]
@@ -236,7 +236,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.TestingConfigProvider do
       fixture_data: %{
         tailwind_versions: ["3.4.17", "4.0.9", "4.1.11"],
         plugin_versions: %{
-          "daisyui" => ["4.12.23", "5.5.19"],
+          "daisyui" => ["4.12.23", "5.5.19", "5.6.7"],
           "test-plugin" => ["1.0.0", "2.0.0"]
         }
       }

--- a/lib/defdo/tailwind_builder/default_config_provider.ex
+++ b/lib/defdo/tailwind_builder/default_config_provider.ex
@@ -18,7 +18,7 @@ defmodule Defdo.TailwindBuilder.DefaultConfigProvider do
       "compatible_versions" => ["3.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.5.19"],
+      "version" => ~s["daisyui": "5.6.7"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/remote_builder.ex
+++ b/lib/defdo/tailwind_builder/remote_builder.ex
@@ -12,7 +12,7 @@ defmodule Defdo.TailwindBuilder.RemoteBuilder do
       {:ok, result} = RemoteBuilder.build_remote([
         version: "4.1.14",
         target_arch: "linux-x64",
-        plugins: [%{name: "daisyui", version: "5.5.19"}],
+        plugins: [%{name: "daisyui", version: "5.6.7"}],
         source_path: "/tmp/tailwind-source"
       ])
 


### PR DESCRIPTION
The canary uses `--config-provider testing`, whose `get_supported_plugins` pins the DaisyUI version — that's what gets baked into the binary (the earlier bump only touched the @available_plugins map). Bump 5.5.19→5.6.7 across all config providers + remote_builder, add 5.6.7 to the version allow-list. Surfaced by v4.3.2-rc1 shipping DaisyUI 5.5.19.