### PR TITLE
ci: cap CARGO_BUILD_JOBS=2 (avoid OOM in 4.3.x oxide build)

### DIFF
--- a/.woodpecker/canary-linux.yml
+++ b/.woodpecker/canary-linux.yml
@@ -47,6 +47,10 @@ steps:
   - name: release-canary-linux
     image: hub.defdo.ninja/defdo/tailwind-builder:latest
     environment:
+      # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
+      # under turbo's parallel workspace build spikes memory and gets OOM-killed
+      # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
+      CARGO_BUILD_JOBS: "2"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:

--- a/.woodpecker/release-linux-arm64.yml
+++ b/.woodpecker/release-linux-arm64.yml
@@ -37,6 +37,10 @@ steps:
   - name: release-linux-arm64
     image: hub.defdo.ninja/defdo/tailwind-builder:latest
     environment:
+      # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
+      # under turbo's parallel workspace build spikes memory and gets OOM-killed
+      # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
+      CARGO_BUILD_JOBS: "2"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:

--- a/.woodpecker/release-macos-arm64.yml
+++ b/.woodpecker/release-macos-arm64.yml
@@ -38,6 +38,10 @@ steps:
   - name: release-macos-arm64
     image: bash
     environment:
+      # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
+      # under turbo's parallel workspace build spikes memory and gets OOM-killed
+      # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
+      CARGO_BUILD_JOBS: "2"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:


### PR DESCRIPTION
Tailwind 4.3.x (rust 1.95) oxide build OOMs under turbo's parallel workspace build → fails at build:wasm → no dist. Direct build:wasm succeeds (toolchain fine); it's memory contention. Cap rust parallelism.