### PR TITLE
ci: CARGO_BUILD_JOBS=1 (jobs=2 still OOMs)

### DIFF
--- a/.woodpecker/canary-linux.yml
+++ b/.woodpecker/canary-linux.yml
@@ -50,7 +50,7 @@ steps:
       # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
       # under turbo's parallel workspace build spikes memory and gets OOM-killed
       # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
-      CARGO_BUILD_JOBS: "2"
+      CARGO_BUILD_JOBS: "1"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:

--- a/.woodpecker/release-linux-arm64.yml
+++ b/.woodpecker/release-linux-arm64.yml
@@ -40,7 +40,7 @@ steps:
       # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
       # under turbo's parallel workspace build spikes memory and gets OOM-killed
       # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
-      CARGO_BUILD_JOBS: "2"
+      CARGO_BUILD_JOBS: "1"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:

--- a/.woodpecker/release-macos-arm64.yml
+++ b/.woodpecker/release-macos-arm64.yml
@@ -41,7 +41,7 @@ steps:
       # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
       # under turbo's parallel workspace build spikes memory and gets OOM-killed
       # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
-      CARGO_BUILD_JOBS: "2"
+      CARGO_BUILD_JOBS: "1"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:


### PR DESCRIPTION
jobs=2 still OOMs the 4.3.x rust build on CI. The confirmed local build used jobs=1. Use 1.