### PR TITLE
fix(daisyui): resolve daisyui/theme via index.js (daisyui >= 5.6)

### DIFF
--- a/.woodpecker/canary-linux.yml
+++ b/.woodpecker/canary-linux.yml
@@ -47,10 +47,6 @@ steps:
   - name: release-canary-linux
     image: hub.defdo.ninja/defdo/tailwind-builder:latest
     environment:
-      # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
-      # under turbo's parallel workspace build spikes memory and gets OOM-killed
-      # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
-      CARGO_BUILD_JOBS: "1"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:

--- a/.woodpecker/release-linux-arm64.yml
+++ b/.woodpecker/release-linux-arm64.yml
@@ -37,10 +37,6 @@ steps:
   - name: release-linux-arm64
     image: hub.defdo.ninja/defdo/tailwind-builder:latest
     environment:
-      # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
-      # under turbo's parallel workspace build spikes memory and gets OOM-killed
-      # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
-      CARGO_BUILD_JOBS: "1"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:

--- a/.woodpecker/release-macos-arm64.yml
+++ b/.woodpecker/release-macos-arm64.yml
@@ -38,10 +38,6 @@ steps:
   - name: release-macos-arm64
     image: bash
     environment:
-      # Limit rust codegen parallelism: the Tailwind 4.3.x oxide build (rust 1.95)
-      # under turbo's parallel workspace build spikes memory and gets OOM-killed
-      # on CI (fails at build:wasm -> no dist). Cap it for reliable builds.
-      CARGO_BUILD_JOBS: "1"
       R2_ACCESS_KEY_ID:
         from_secret: r2_access_key_id
       R2_SECRET_ACCESS_KEY:

--- a/lib/defdo/tailwind_builder/plugin_manager.ex
+++ b/lib/defdo/tailwind_builder/plugin_manager.ex
@@ -420,10 +420,15 @@ defmodule Defdo.TailwindBuilder.PluginManager do
   defp patch_tw_load(content, plugin_name) do
     patch_string_at = ~s[    return require('@tailwindcss/aspect-ratio')]
 
-    # Special handling for daisyui to support daisyui/theme
+    # Special handling for daisyui to support daisyui/theme.
+    # daisyui >= 5.6 ships `theme` as a directory (with index.js) and adds an
+    # `exports` map ({".":..., "./*":"./*"}) that disables directory-index
+    # resolution for bare subpaths, so `daisyui/theme` no longer resolves — the
+    # bundler needs the explicit `daisyui/theme/index.js`. We keep matching the
+    # id the user references (`daisyui/theme`) but resolve the concrete file.
     patch_text =
       if plugin_name == "daisyui" do
-        ~s[\n  } else if (id.endsWith('daisyui/theme')) {\n    return require('daisyui/theme')\n  } else if (/(\\/)?daisyui(\\/(?!theme).+)?$/.test(id)) {\n    return require('daisyui')]
+        ~s[\n  } else if (id.endsWith('daisyui/theme')) {\n    return require('daisyui/theme/index.js')\n  } else if (/(\\/)?daisyui(\\/(?!theme).+)?$/.test(id)) {\n    return require('daisyui')]
       else
         ~s[\n  } else if (/(\\/)?#{plugin_name}(\\/.+)?$/.test(id)) {\n    return require('#{plugin_name}')]
       end
@@ -439,10 +444,13 @@ defmodule Defdo.TailwindBuilder.PluginManager do
       'tailwindcss/defaultTheme.js': await import('tailwindcss/defaultTheme'),
     """
 
-    # Special handling for daisyui to support daisyui/theme
+    # Special handling for daisyui to support daisyui/theme (see patch_tw_load:
+    # daisyui >= 5.6 needs the explicit `daisyui/theme/index.js`). The import-map
+    # key stays `daisyui/theme` (what the user references); only the resolved
+    # module path is made explicit.
     patch_text =
       if plugin_name == "daisyui" do
-        ~s[      '#{plugin_name}': await import('#{plugin_name}'),\n      '#{plugin_name}/theme': await import('#{plugin_name}/theme'),]
+        ~s[      '#{plugin_name}': await import('#{plugin_name}'),\n      '#{plugin_name}/theme': await import('#{plugin_name}/theme/index.js'),]
       else
         ~s[      '#{plugin_name}': await import('#{plugin_name}'),]
       end


### PR DESCRIPTION
daisyui 5.6 made `theme` a directory + added an `exports` map, so the injected `daisyui/theme` no longer resolves → bun standalone build fails (`Could not resolve: daisyui/theme`). Resolve `daisyui/theme/index.js` explicitly (user-facing id unchanged). Confirmed: standalone builds + runs with daisyui 5.6.7. Also removes the CARGO_BUILD_JOBS=1 red-herring (failure was this JS resolve, not rust OOM).