### PR TITLE
feat: DaisyUI 5.6.10 (latest)

### DIFF
--- a/lib/defdo/tailwind_builder.ex
+++ b/lib/defdo/tailwind_builder.ex
@@ -37,7 +37,7 @@ defmodule Defdo.TailwindBuilder do
       "statement" => ~s['daisyui': require('daisyui')]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.6.7"]
+      "version" => ~s["daisyui": "5.6.10"]
       # No "statement" for v4.x - uses index.ts patching with ES modules instead
     }
   }

--- a/lib/defdo/tailwind_builder/build_quick_test.ex
+++ b/lib/defdo/tailwind_builder/build_quick_test.ex
@@ -31,14 +31,14 @@ defmodule Defdo.TailwindBuilder.BuildQuickTest do
   @test_scenarios %{
     v4_basic: %{
       version: "4.2.2",
-      plugin: %{"version" => ~s["daisyui": "5.6.7"]},
+      plugin: %{"version" => ~s["daisyui": "5.6.10"]},
       description: "Basic Tailwind v4 with DaisyUI v5",
       expected_duration_ms: 90_000,
       test_css: "@import \"tailwindcss\"; @plugin \"daisyui\";"
     },
     v4_with_theme: %{
       version: "4.2.2",
-      plugin: %{"version" => ~s["daisyui": "5.6.7"]},
+      plugin: %{"version" => ~s["daisyui": "5.6.10"]},
       theme: %{
         "mytheme" => %{
           "primary" => "#570df8",
@@ -65,7 +65,7 @@ defmodule Defdo.TailwindBuilder.BuildQuickTest do
     },
     cross_platform: %{
       version: "4.2.2",
-      plugin: %{"version" => ~s["daisyui": "5.6.7"]},
+      plugin: %{"version" => ~s["daisyui": "5.6.10"]},
       target_arch: "linux-x64",
       description: "Cross-platform build test (macOS → Linux)",
       expected_duration_ms: 100_000,

--- a/lib/defdo/tailwind_builder/config_providers/development_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/development_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.DevelopmentConfigProvider do
       "compatible_versions" => ["3.x", "4.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.6.7"],
+      "version" => ~s["daisyui": "5.6.10"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/config_providers/production_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/production_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.ProductionConfigProvider do
       "compatible_versions" => ["3.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.6.7"],
+      "version" => ~s["daisyui": "5.6.10"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/config_providers/staging_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/staging_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.StagingConfigProvider do
       "compatible_versions" => ["3.x", "4.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.6.7"],
+      "version" => ~s["daisyui": "5.6.10"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/config_providers/testing_config_provider.ex
+++ b/lib/defdo/tailwind_builder/config_providers/testing_config_provider.ex
@@ -22,7 +22,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.TestingConfigProvider do
       "compatible_versions" => ["3.x", "4.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.6.7"],
+      "version" => ~s["daisyui": "5.6.10"],
       "description" => "Test plugin for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]
@@ -236,7 +236,7 @@ defmodule Defdo.TailwindBuilder.ConfigProviders.TestingConfigProvider do
       fixture_data: %{
         tailwind_versions: ["3.4.17", "4.0.9", "4.1.11"],
         plugin_versions: %{
-          "daisyui" => ["4.12.23", "5.5.19", "5.6.7"],
+          "daisyui" => ["4.12.23", "5.5.19", "5.6.10"],
           "test-plugin" => ["1.0.0", "2.0.0"]
         }
       }

--- a/lib/defdo/tailwind_builder/default_config_provider.ex
+++ b/lib/defdo/tailwind_builder/default_config_provider.ex
@@ -18,7 +18,7 @@ defmodule Defdo.TailwindBuilder.DefaultConfigProvider do
       "compatible_versions" => ["3.x"]
     },
     "daisyui_v5" => %{
-      "version" => ~s["daisyui": "5.6.7"],
+      "version" => ~s["daisyui": "5.6.10"],
       "description" => "Semantic component classes for Tailwind CSS v5",
       "npm_name" => "daisyui",
       "compatible_versions" => ["4.x"]

--- a/lib/defdo/tailwind_builder/remote_builder.ex
+++ b/lib/defdo/tailwind_builder/remote_builder.ex
@@ -12,7 +12,7 @@ defmodule Defdo.TailwindBuilder.RemoteBuilder do
       {:ok, result} = RemoteBuilder.build_remote([
         version: "4.1.14",
         target_arch: "linux-x64",
-        plugins: [%{name: "daisyui", version: "5.6.7"}],
+        plugins: [%{name: "daisyui", version: "5.6.10"}],
         source_path: "/tmp/tailwind-source"
       ])
 

--- a/lib/mix/tasks/tailwind/release.ex
+++ b/lib/mix/tasks/tailwind/release.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Tailwind.Release do
   @moduledoc """
   Build and publish a Tailwind standalone release candidate.
 
-  Defaults to Tailwind 4.3.2 with DaisyUI 5.6.7 and release channel v4.3.2-rc1.
+  Defaults to Tailwind 4.3.2 with DaisyUI 5.6.10 and release channel v4.3.2-rc1.
 
   ## Options
 

--- a/test/defdo/tailwind_builder/release_test.exs
+++ b/test/defdo/tailwind_builder/release_test.exs
@@ -106,7 +106,7 @@ defmodule Defdo.TailwindBuilder.ReleaseTest do
         assert result.release_channel == "v4.2.2-rc1"
 
         assert result.plugin_set == [
-                 %{name: "daisyui", version: "5.6.7", plugin_key: "daisyui_v5"}
+                 %{name: "daisyui", version: "5.6.10", plugin_key: "daisyui_v5"}
                ]
 
         assert result.deploy.binaries_deployed == 3
@@ -117,7 +117,7 @@ defmodule Defdo.TailwindBuilder.ReleaseTest do
                  "b8ff36e8115f56883638d593563418ee279be9f8304107add89f79d9cbf5b147"
 
         assert_received {:plugin_opts, plugin_spec, plugin_opts}
-        assert plugin_spec["version"] == ~s["daisyui": "5.6.7"]
+        assert plugin_spec["version"] == ~s["daisyui": "5.6.10"]
         assert plugin_opts[:base_path] == source_path
         assert plugin_opts[:version] == "4.2.2"
 


### PR DESCRIPTION
Bump the canary DaisyUI pin 5.6.7→5.6.10 (latest). Same package layout as 5.6.7, so the daisyui/theme/index.js fix applies. Config providers + map + release default + release_test updated.